### PR TITLE
fix: Codacy/SonarCloud issues + PyPI publish workflow

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,16 @@
+---
+engines:
+  bandit:
+    enabled: true
+    exclude_paths:
+      - "test/**"
+      - "tests/**"
+      - "build/**"
+      - "dist/**"
+exclude_paths:
+  - "test/**"
+  - "tests/**"
+  - "docs/**"
+  - "build/**"
+  - "dist/**"
+  - "**/__pycache__/**"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'chore: bump version')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Bump patch version in pyproject.toml
+        id: bump
+        run: |
+          python <<'EOF'
+          import os
+          import pathlib
+          import re
+
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          match = re.search(r'^version\s*=\s*"(\d+)\.(\d+)\.(\d+)"', text, re.MULTILINE)
+          if not match:
+              raise SystemExit("Could not find version in pyproject.toml")
+          major, minor, patch = (int(part) for part in match.groups())
+          new_version = f"{major}.{minor}.{patch + 1}"
+          new_text = re.sub(
+              r'^(version\s*=\s*)"\d+\.\d+\.\d+"',
+              rf'\1"{new_version}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          path.write_text(new_text, encoding="utf-8")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"new_version={new_version}\n")
+          print(f"Bumped version -> {new_version}")
+          EOF
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --non-interactive dist/*
+
+      - name: Commit and tag version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
+          git tag "v${{ steps.bump.outputs.new_version }}"
+          git push origin main
+          git push origin "v${{ steps.bump.outputs.new_version }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.bump.outputs.new_version }}" \
+            dist/* \
+            --title "v${{ steps.bump.outputs.new_version }}" \
+            --generate-notes

--- a/dev.toml
+++ b/dev.toml
@@ -1,7 +1,7 @@
 # Rename to build dev version
 # This is dev version
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'APITestka'
-copyright = '2020 ~ Now, JE-Chen'
+project_copyright = '2020 ~ Now, JE-Chen'
 author = 'JE-Chen'
 
 # -- General configuration ---------------------------------------------------

--- a/je_api_testka/gui/api_testka_gui_thread.py
+++ b/je_api_testka/gui/api_testka_gui_thread.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import traceback
 
 from PySide6.QtCore import QThread
@@ -116,21 +115,29 @@ class ExecutorThread(QThread):
         self.action_list = None
         self.file_list = None
 
+    @staticmethod
+    def _emit_result_dict(result: dict) -> None:
+        for key, value in result.items():
+            api_testka_ui_queue.put(f"{key}")
+            api_testka_ui_queue.put(f"  => {value}")
+
+    def _run_action_mode(self) -> None:
+        result = execute_action(self.action_list)
+        self._emit_result_dict(result)
+
+    def _run_files_mode(self) -> None:
+        results = execute_files(self.file_list)
+        for i, result in enumerate(results):
+            api_testka_ui_queue.put(f"--- File {i + 1} ---")
+            if isinstance(result, dict):
+                self._emit_result_dict(result)
+
     def run(self):
         try:
             if self.mode == "action" and self.action_list:
-                result = execute_action(self.action_list)
-                for key, value in result.items():
-                    api_testka_ui_queue.put(f"{key}")
-                    api_testka_ui_queue.put(f"  => {value}")
+                self._run_action_mode()
             elif self.mode == "files" and self.file_list:
-                results = execute_files(self.file_list)
-                for i, result in enumerate(results):
-                    api_testka_ui_queue.put(f"--- File {i + 1} ---")
-                    if isinstance(result, dict):
-                        for key, value in result.items():
-                            api_testka_ui_queue.put(f"{key}")
-                            api_testka_ui_queue.put(f"  => {value}")
+                self._run_files_mode()
         except Exception as error:
             api_testka_ui_queue.put(f"Executor Error: {repr(error)}")
             api_testka_ui_queue.put(traceback.format_exc())

--- a/je_api_testka/gui/main_widget.py
+++ b/je_api_testka/gui/main_widget.py
@@ -20,6 +20,9 @@ from je_api_testka.utils.test_record.test_record_class import test_record_instan
 from je_api_testka.utils.file_process.get_dir_file_list import get_dir_files_as_list
 
 
+_JSON_FILE_FILTER = "JSON Files (*.json)"
+
+
 def _t(key):
     """Shorthand to get translated string."""
     return language_wrapper.language_word_dict.get(key, key)
@@ -282,7 +285,7 @@ class APITestkaWidget(QWidget):
         self._start_thread(thread)
 
     def _on_executor_browse_file(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Select JSON File", "", "JSON Files (*.json)")
+        path, _ = QFileDialog.getOpenFileName(self, "Select JSON File", "", _JSON_FILE_FILTER)
         if path:
             self.executor_file_input.setText(path)
 
@@ -531,7 +534,7 @@ class APITestkaWidget(QWidget):
             self.tools_json_output.setPlainText(f"Error: {e}")
 
     def _on_json_read(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Read JSON", "", "JSON Files (*.json)")
+        path, _ = QFileDialog.getOpenFileName(self, "Read JSON", "", _JSON_FILE_FILTER)
         if not path:
             return
         try:
@@ -544,7 +547,7 @@ class APITestkaWidget(QWidget):
         text = self.tools_json_input.toPlainText().strip()
         if not text:
             return
-        path, _ = QFileDialog.getSaveFileName(self, "Write JSON", "", "JSON Files (*.json)")
+        path, _ = QFileDialog.getSaveFileName(self, "Write JSON", "", _JSON_FILE_FILTER)
         if not path:
             return
         try:

--- a/je_api_testka/gui/main_window.py
+++ b/je_api_testka/gui/main_window.py
@@ -1,7 +1,7 @@
 import sys
 
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMainWindow, QApplication, QMessageBox
+from PySide6.QtWidgets import QMainWindow, QApplication
 from qt_material import QtStyleTools
 
 from je_api_testka.gui.language_wrapper.multi_language_wrapper import language_wrapper

--- a/je_api_testka/httpx_wrapper/async_httpx_method.py
+++ b/je_api_testka/httpx_wrapper/async_httpx_method.py
@@ -28,7 +28,7 @@ http_method_dict = {
 }
 
 
-async def get_http_method_httpx_async(http_method: str):
+def get_http_method_httpx_async(http_method: str):
     """
     根據字串取得對應的 HTTP 方法，若不存在則拋出例外
     Get corresponding HTTP method from string, raise exception if not exists
@@ -46,7 +46,7 @@ async def get_http_method_httpx_async(http_method: str):
     return http_method_dict[http_method]
 
 
-async def get_httpx_response_async(
+def get_httpx_response_async(
     response: Response, start_time: Union[str, float, int, datetime], end_time: Union[str, float, int, datetime]
 ) -> Dict[str, str]:
     """
@@ -77,7 +77,7 @@ async def send_httpx_requests_async(
         "async_httpx_method.py send_httpx_requests_async "
         f"http_method: {http_method} test_url: {test_url} timeout: {timeout} http2: {http2} kwargs: {kwargs}"
     )
-    await get_http_method_httpx_async(http_method)
+    get_http_method_httpx_async(http_method)
     async with AsyncClient(http2=http2) as client:
         client_method_dict = {
             "get": client.get,
@@ -89,7 +89,8 @@ async def send_httpx_requests_async(
             "options": client.options,
         }
         method = client_method_dict[http_method.lower()]
-        response = await method(url=test_url, timeout=timeout, **kwargs)
+        # Enforce timeout via asyncio.wait_for context (asyncio.timeout requires 3.11+).
+        response = await asyncio.wait_for(method(url=test_url, **kwargs), timeout=timeout)
     return response
 
 
@@ -118,7 +119,7 @@ async def test_api_method_httpx_async(
             http_method, test_url=test_url, timeout=timeout, http2=http2, **kwargs
         )
         end_time = datetime.now()
-        response_data = await get_httpx_response_async(response, start_time, end_time)
+        response_data = get_httpx_response_async(response, start_time, end_time)
         response.raise_for_status()
         if clean_record:
             test_record_instance.clean_record()

--- a/je_api_testka/utils/generate_report/xml_report.py
+++ b/je_api_testka/utils/generate_report/xml_report.py
@@ -23,8 +23,8 @@ def generate_xml() -> Tuple[str, str]:
 
     # 包裝成 xml_data 根節點
     # Wrap into xml_data root node
-    success_dict = dict({"xml_data": success_dict})
-    failure_dict = dict({"xml_data": failure_dict})
+    success_dict = {"xml_data": success_dict}
+    failure_dict = {"xml_data": failure_dict}
 
     # 將 dict 轉換為 XML 結構字串
     # Convert dict to XML structure string

--- a/je_api_testka/utils/package_manager/package_manager_class.py
+++ b/je_api_testka/utils/package_manager/package_manager_class.py
@@ -34,7 +34,9 @@ class PackageManager:
             found_spec = find_spec(package)
             if found_spec is not None:
                 try:
-                    installed_package = import_module(found_spec.name)
+                    # Plugin loader: package name resolved through importlib.find_spec first,
+                    # so import_module receives a verified spec.name, not raw user input.
+                    installed_package = import_module(found_spec.name)  # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
                     self.installed_package_dict.update({found_spec.name: installed_package})
                 except ModuleNotFoundError as error:
                     apitestka_logger.error(repr(error))

--- a/je_api_testka/utils/project/create_project_structure.py
+++ b/je_api_testka/utils/project/create_project_structure.py
@@ -15,6 +15,10 @@ from je_api_testka.utils.project.template.template_keyword import (
     bad_template_1,
 )
 
+_KEYWORD_DIR = "/keyword"
+_EXECUTOR_DIR = "/executor"
+_TEMP_PLACEHOLDER = "{temp}"
+
 
 def create_dir(dir_name: str) -> None:
     """
@@ -47,39 +51,41 @@ def create_template(parent_name: str, project_path: str = None) -> None:
     if project_path is None:
         project_path = getcwd()
 
-    keyword_dir_path = Path(project_path + "/" + parent_name + "/keyword")
-    executor_dir_path = Path(project_path + "/" + parent_name + "/executor")
+    keyword_base = project_path + "/" + parent_name + _KEYWORD_DIR
+    executor_base = project_path + "/" + parent_name + _EXECUTOR_DIR
+    keyword_dir_path = Path(keyword_base)
+    executor_dir_path = Path(executor_base)
     lock = Lock()
 
     # 建立 keyword 範本 JSON 檔案 / Create keyword template JSON files
     if keyword_dir_path.exists() and keyword_dir_path.is_dir():
-        write_action_json(project_path + "/" + parent_name + "/keyword/keyword1.json", template_keyword_1)
-        write_action_json(project_path + "/" + parent_name + "/keyword/keyword2.json", template_keyword_2)
-        write_action_json(project_path + "/" + parent_name + "/keyword/bad_keyword_1.json", bad_template_1)
+        write_action_json(keyword_base + "/keyword1.json", template_keyword_1)
+        write_action_json(keyword_base + "/keyword2.json", template_keyword_2)
+        write_action_json(keyword_base + "/bad_keyword_1.json", bad_template_1)
 
     # 建立 executor 範本 Python 檔案 / Create executor template Python files
     if executor_dir_path.exists() and executor_dir_path.is_dir():
         lock.acquire()
         try:
-            with open(project_path + "/" + parent_name + "/executor/executor_one_file.py", "w+") as file:
+            with open(executor_base + "/executor_one_file.py", "w+") as file:
                 file.write(
                     executor_template_1.replace(
-                        "{temp}",
-                        project_path + "/" + parent_name + "/keyword/keyword1.json"
+                        _TEMP_PLACEHOLDER,
+                        keyword_base + "/keyword1.json"
                     )
                 )
-            with open(project_path + "/" + parent_name + "/executor/executor_bad_file.py", "w+") as file:
+            with open(executor_base + "/executor_bad_file.py", "w+") as file:
                 file.write(
                     bad_executor_template_1.replace(
-                        "{temp}",
-                        project_path + "/" + parent_name + "/keyword/bad_keyword_1.json"
+                        _TEMP_PLACEHOLDER,
+                        keyword_base + "/bad_keyword_1.json"
                     )
                 )
-            with open(project_path + "/" + parent_name + "/executor/executor_folder.py", "w+") as file:
+            with open(executor_base + "/executor_folder.py", "w+") as file:
                 file.write(
                     executor_template_2.replace(
-                        "{temp}",
-                        project_path + "/" + parent_name + "/keyword"
+                        _TEMP_PLACEHOLDER,
+                        keyword_base
                     )
                 )
         finally:
@@ -103,8 +109,8 @@ def create_project_dir(project_path: str = None, parent_name: str = "APITestka")
         project_path = getcwd()
 
     # 建立 keyword 與 executor 資料夾 / Create keyword and executor directories
-    create_dir(project_path + "/" + parent_name + "/keyword")
-    create_dir(project_path + "/" + parent_name + "/executor")
+    create_dir(project_path + "/" + parent_name + _KEYWORD_DIR)
+    create_dir(project_path + "/" + parent_name + _EXECUTOR_DIR)
 
     # 建立範本檔案 / Generate template files
     create_template(parent_name, project_path)

--- a/je_api_testka/utils/xml/change_xml_structure/change_xml_structure.py
+++ b/je_api_testka/utils/xml/change_xml_structure/change_xml_structure.py
@@ -1,7 +1,28 @@
 from collections import defaultdict
-from xml.etree import ElementTree
+# Used for XML serialization only (Element/SubElement/tostring); defusedxml does not
+# provide write APIs. Inputs come from internal dicts, never from untrusted XML data.
+from xml.etree import ElementTree  # nosec B405  # nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
 
 from je_api_testka.utils.logging.loggin_instance import apitestka_logger
+
+
+def _collapse_children(children) -> dict:
+    """Recursively collapse children into a {tag: value | [values]} mapping."""
+    grouped = defaultdict(list)
+    for child_dict in map(elements_tree_to_dict, children):
+        for key, value in child_dict.items():
+            grouped[key].append(value)
+    return {key: value[0] if len(value) == 1 else value for key, value in grouped.items()}
+
+
+def _apply_text(elements_dict: dict, tag, text_raw: str, has_children: bool, has_attrib: bool) -> None:
+    """Apply element text into the result dict, respecting children/attrib presence."""
+    text = text_raw.strip()
+    if has_children or has_attrib:
+        if text:
+            elements_dict[tag]['#text'] = text
+    else:
+        elements_dict[tag] = text
 
 
 def elements_tree_to_dict(elements_tree) -> dict:
@@ -14,41 +35,59 @@ def elements_tree_to_dict(elements_tree) -> dict:
     """
     apitestka_logger.info(f"change_xml_structure.py elements_tree_to_dict elements_tree: {elements_tree}")
 
-    # 初始化字典，若有屬性則為空 dict，否則為 None
-    # Initialize dict: empty if attributes exist, else None
-    elements_dict: dict = {elements_tree.tag: {} if elements_tree.attrib else None}
+    tag = elements_tree.tag
+    has_attrib = bool(elements_tree.attrib)
+    elements_dict: dict = {tag: {} if has_attrib else None}
 
-    # 取得子節點 / Get children nodes
-    children: list = list(elements_tree)
+    children = list(elements_tree)
     if children:
-        default_dict = defaultdict(list)
-        # 遞迴處理子節點 / Recursively process children
-        for dc in map(elements_tree_to_dict, children):
-            for key, value in dc.items():
-                default_dict[key].append(value)
-        # 若同名子節點只有一個，直接取值；否則保留為 list
-        # If only one child with same tag, use value directly; else keep as list
-        elements_dict: dict = {
-            elements_tree.tag: {key: value[0] if len(value) == 1 else value for key, value in default_dict.items()}
-        }
+        elements_dict = {tag: _collapse_children(children)}
 
-    # 處理屬性，將其加入字典，並以 '@' 作為前綴
-    # Handle attributes, add to dict with '@' prefix
-    if elements_tree.attrib:
-        elements_dict[elements_tree.tag].update(
+    if has_attrib:
+        elements_dict[tag].update(
             ('@' + key, value) for key, value in elements_tree.attrib.items()
         )
 
-    # 處理文字內容 / Handle text content
     if elements_tree.text:
-        text = elements_tree.text.strip()
-        if children or elements_tree.attrib:
-            if text:
-                elements_dict[elements_tree.tag]['#text'] = text
-        else:
-            elements_dict[elements_tree.tag] = text
+        _apply_text(elements_dict, tag, elements_tree.text, bool(children), has_attrib)
 
     return elements_dict
+
+
+def _set_text_marker(root, key: str, value) -> None:
+    if key != '#text' or not isinstance(value, str):
+        raise ValueError(f"Only '#text' key with str value is allowed, got key={key!r}")
+    root.text = value
+
+
+def _set_attribute(root, key: str, value) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"XML attribute value must be str, got {type(value).__name__}")
+    root.set(key[1:], value)
+
+
+def _handle_dict_entry(key, value, root) -> None:
+    if not isinstance(key, str):
+        raise TypeError(f"XML dict key must be str, got {type(key).__name__}")
+    if key.startswith('#'):
+        _set_text_marker(root, key, value)
+    elif key.startswith('@'):
+        _set_attribute(root, key, value)
+    elif isinstance(value, list):
+        for elements in value:
+            _to_elements_tree(elements, ElementTree.SubElement(root, key))
+    else:
+        _to_elements_tree(value, ElementTree.SubElement(root, key))
+
+
+def _to_elements_tree(json_dict, root) -> None:
+    if isinstance(json_dict, str):
+        root.text = json_dict
+    elif isinstance(json_dict, dict):
+        for key, value in json_dict.items():
+            _handle_dict_entry(key, value, root)
+    else:
+        raise TypeError('invalid type: ' + str(type(json_dict)))
 
 
 def dict_to_elements_tree(json_dict: dict) -> str:
@@ -61,40 +100,10 @@ def dict_to_elements_tree(json_dict: dict) -> str:
     """
     apitestka_logger.info(f"change_xml_structure.py dict_to_elements_tree json_dict: {json_dict}")
 
-    def _to_elements_tree(json_dict: dict, root):
-        # 若為字串，直接設為節點文字 / If string, set as node text
-        if isinstance(json_dict, str):
-            root.text = json_dict
-        elif isinstance(json_dict, dict):
-            for key, value in json_dict.items():
-                if not isinstance(key, str):
-                    raise TypeError(f"XML dict key must be str, got {type(key).__name__}")
-                if key.startswith('#'):
-                    # 特殊標記 '#text' 表示文字內容 / Special key '#text' means text content
-                    if key != '#text' or not isinstance(value, str):
-                        raise ValueError(f"Only '#text' key with str value is allowed, got key={key!r}")
-                    root.text = value
-                elif key.startswith('@'):
-                    # 特殊標記 '@' 表示屬性 / Special key '@' means attribute
-                    if not isinstance(value, str):
-                        raise TypeError(f"XML attribute value must be str, got {type(value).__name__}")
-                    root.set(key[1:], value)
-                elif isinstance(value, list):
-                    # 若值為 list，建立多個子節點 / If value is list, create multiple sub-elements
-                    for elements in value:
-                        _to_elements_tree(elements, ElementTree.SubElement(root, key))
-                else:
-                    # 遞迴建立子節點 / Recursively create sub-element
-                    _to_elements_tree(value, ElementTree.SubElement(root, key))
-        else:
-            raise TypeError('invalid type: ' + str(type(json_dict)))
-
-    # 確保字典只有一個根節點 / Ensure dict has only one root element
     if not isinstance(json_dict, dict) or len(json_dict) != 1:
         raise ValueError("json_dict must be a dict with exactly one root element")
     tag, body = next(iter(json_dict.items()))
     node = ElementTree.Element(tag)
     _to_elements_tree(body, node)
 
-    # 將 XML 轉換為字串並回傳 / Convert XML to string and return
     return str(ElementTree.tostring(node), encoding="utf-8")

--- a/je_api_testka/utils/xml/xml_file/xml_file.py
+++ b/je_api_testka/utils/xml/xml_file/xml_file.py
@@ -1,5 +1,7 @@
 from defusedxml import ElementTree, minidom
-from xml.etree import ElementTree as _WriterElementTree
+# _WriterElementTree is used only for write_xml serialization (ElementTree(...).write).
+# Parsing is delegated to defusedxml above.
+from xml.etree import ElementTree as _WriterElementTree  # nosec B405  # nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
 
 from je_api_testka.utils.exception.exception_tags import cant_read_xml_error, xml_type_error
 from je_api_testka.utils.exception.exceptions import APITesterXMLException, APITesterXMLTypeException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Rename to build stable version
 # This is stable version
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -44,3 +44,7 @@ gui = ["PySide6==6.11.0", "qt-material"]
 testpaths = ["test"]
 asyncio_mode = "auto"
 timeout = 30
+
+[tool.bandit]
+# Test code uses assert by design (pytest); see CLAUDE.md "Test Code Exemptions".
+exclude_dirs = ["test", "tests", "build", "dist", ".venv", "venv"]

--- a/test/test_requests/test_http_methods.py
+++ b/test/test_requests/test_http_methods.py
@@ -1,5 +1,3 @@
-import pytest
-
 from je_api_testka import test_api_method_requests as api_requests
 
 


### PR DESCRIPTION
## Summary
- Resolve all 12 SonarCloud open issues and the meaningful Codacy issues (8 source-file findings + the test-file Bandit-B101 noise via config exclusion).
- Add PyPI publish workflow that bumps version, builds, uploads, tags, and creates a release on every push to `main`.
- Align `dev.toml` setuptools pin with `pyproject.toml` (`>=82.0.1`).

### Code-quality fixes
- **S3776 cognitive complexity**: extracted helpers in `change_xml_structure.py` (18 + 36 → under 15) and `api_testka_gui_thread.ExecutorThread.run` (16 → under 15).
- **S1192 duplicated literals**: `_JSON_FILE_FILTER` in `main_widget.py`; `_KEYWORD_DIR` / `_EXECUTOR_DIR` / `_TEMP_PLACEHOLDER` in `create_project_structure.py`.
- **S7503 async without await**: converted `get_http_method_httpx_async` and `get_httpx_response_async` to sync (only callers were in-file).
- **S7483 timeout parameter**: replaced `timeout=` kwarg to httpx with `asyncio.wait_for(...)` so timeout is enforced via a context-style mechanism (3.10-compatible alternative to `asyncio.timeout`).
- **S7496 redundant dict()**: unwrapped `dict({...})` literals in `xml_report.generate_xml`.

### Codacy source-file fixes
- Removed unused imports (`QMessageBox`, `json`, `pytest`).
- Justified write-only `xml.etree` imports with `# nosec B405` / `# nosemgrep` comments — defusedxml has no write API.
- Justified plugin-loader `import_module(found_spec.name)` with a `# nosemgrep` comment; the package name is verified through `find_spec` first.
- Switched Sphinx `copyright =` → `project_copyright =` to stop shadowing the builtin (W0622).

### Bandit B101 noise (142 in tests)
- Added `[tool.bandit] exclude_dirs` in `pyproject.toml` and a new `.codacy.yaml` excluding `test/**` from Bandit. Tests legitimately use `assert` per `CLAUDE.md`.

### CI
- New `.github/workflows/publish.yml`: on push to `main`, bumps patch version in `pyproject.toml`, builds the sdist+wheel, uploads via Twine using `PYPI_API_TOKEN`, commits the bump, tags `vX.Y.Z`, and publishes a GitHub release.

## Test plan
- [x] `pytest -x` — 75 passed in 13.8s locally.
- [ ] Verify Codacy and SonarCloud reanalyses show the open-issue counts drop to 0 (or near-0) after merge.
- [ ] Verify the publish workflow runs once `main` receives the merge (or dry-run review the workflow before merging).