### PR TITLE
feat: register 23 more helpers as AT_ executor commands (executor 48 → 71)

### DIFF
--- a/je_api_testka/runner/parallel_runner.py
+++ b/je_api_testka/runner/parallel_runner.py
@@ -11,7 +11,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List
 
 from je_api_testka.runner.metadata import strip_runner_metadata
-from je_api_testka.utils.executor.action_executor import executor
 from je_api_testka.utils.logging.loggin_instance import apitestka_logger
 
 DEFAULT_MAX_WORKERS: int = 8
@@ -23,7 +22,11 @@ def run_actions_parallel(actions: List[list], max_workers: int = DEFAULT_MAX_WOR
     apitestka_logger.info(
         f"parallel_runner run_actions_parallel actions: {len(actions)} max_workers: {max_workers}"
     )
-    runner = runner or executor.execute_action
+    if runner is None:
+        # Lazy import: executor module imports the runner package, so importing
+        # it at module top creates a circular dependency.
+        from je_api_testka.utils.executor.action_executor import executor
+        runner = executor.execute_action
     cleaned = [strip_runner_metadata(action) for action in actions]
     results: Dict[int, Any] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as pool:

--- a/je_api_testka/utils/executor/action_executor.py
+++ b/je_api_testka/utils/executor/action_executor.py
@@ -13,24 +13,42 @@ from je_api_testka.data.variable_store import extract_and_store, variable_store
 from je_api_testka.diff.contract_diff import diff_openapi_specs
 from je_api_testka.diff.response_diff import diff_payloads
 from je_api_testka.diff.sla_check import assert_sla
+from je_api_testka.graphql_wrapper.graphql_method import test_api_method_graphql
 from je_api_testka.httpx_wrapper.async_httpx_method import delegate_async_httpx
 from je_api_testka.integrations.curl_import import curl_to_action
 from je_api_testka.integrations.github_pr_comment import post_pr_comment
 from je_api_testka.integrations.har_import import convert_har
 from je_api_testka.integrations.notify import notify_via_webhook
 from je_api_testka.requests_wrapper.request_method import test_api_method_requests
+from je_api_testka.runner.dependency_runner import order_actions
+from je_api_testka.runner.parallel_runner import run_actions_parallel
+from je_api_testka.runner.tag_filter import filter_actions_by_tag
+from je_api_testka.security.auth_helpers import (
+    aws_sigv4_headers,
+    basic_auth_header,
+    bearer_token_header,
+    build_jwt,
+)
 from je_api_testka.security.cors_check import cors_preflight
+from je_api_testka.security.cve_check import run_pip_audit
+from je_api_testka.security.fuzz import fuzz_string_inputs
+from je_api_testka.security.header_scan import scan_security_headers
 from je_api_testka.security.rate_limit_probe import probe_rate_limit
 from je_api_testka.security.ssrf_check import probe_ssrf
 from je_api_testka.spec.openapi_changelog import openapi_changelog
 from je_api_testka.spec.records_to_openapi import records_to_openapi
 from je_api_testka.spec.schema_inference import infer_schema
+from je_api_testka.sse_wrapper.sse_method import test_api_method_sse
+from je_api_testka.utils.assert_result.schema_check import check_json_schema, check_jsonpath
+from je_api_testka.utils.assert_result.snapshot import assert_snapshot
 from je_api_testka.utils.exception.exception_tags import add_command_exception_tag
 from je_api_testka.utils.exception.exception_tags import executor_data_error, executor_list_error
 from je_api_testka.utils.exception.exceptions import APITesterExecuteException, APIAddCommandException
+from je_api_testka.utils.generate_report.allure_report import generate_allure_report
 from je_api_testka.utils.generate_report.badge import generate_badge
 from je_api_testka.utils.generate_report.html_report_generate import generate_html, generate_html_report
 from je_api_testka.utils.generate_report.json_report import generate_json, generate_json_report
+from je_api_testka.utils.generate_report.junit_report import generate_junit_report
 from je_api_testka.utils.generate_report.markdown_report import generate_markdown_report, render_markdown
 from je_api_testka.utils.generate_report.run_diff import diff_runs
 from je_api_testka.utils.generate_report.trend_store import list_trend_rows, record_current_run
@@ -39,6 +57,7 @@ from je_api_testka.utils.json.json_file.json_file import read_action_json
 from je_api_testka.utils.logging.loggin_instance import apitestka_logger
 from je_api_testka.utils.mock_server.flask_mock_server import flask_mock_server_instance
 from je_api_testka.utils.package_manager.package_manager_class import package_manager
+from je_api_testka.websocket_wrapper.websocket_method import test_api_method_websocket
 
 
 def _cassette_lookup(file_path: str, method: str, url: str, body: str = "") -> dict:
@@ -128,6 +147,38 @@ class Executor:
             "AT_classify_failures": classify_failures,
             "AT_generate_fake_payload": generate_fake_payload,
             "AT_generate_tests_from_openapi": generate_tests_from_openapi,
+            # Extra protocol backends (sync entry points only; async variants
+            # are intentionally not registered because they return coroutines
+            # that the executor would not await).
+            "AT_test_api_method_websocket": test_api_method_websocket,
+            "AT_test_api_method_sse": test_api_method_sse,
+            "AT_test_api_method_graphql": test_api_method_graphql,
+            # Schema / JSONPath / snapshot assertions
+            "AT_check_json_schema": check_json_schema,
+            "AT_check_jsonpath": check_jsonpath,
+            "AT_assert_snapshot": assert_snapshot,
+            # Auth helpers
+            "AT_basic_auth_header": basic_auth_header,
+            "AT_bearer_token_header": bearer_token_header,
+            "AT_build_jwt": build_jwt,
+            "AT_aws_sigv4_headers": aws_sigv4_headers,
+            # Security scans
+            "AT_scan_security_headers": scan_security_headers,
+            "AT_fuzz_string_inputs": fuzz_string_inputs,
+            "AT_run_pip_audit": run_pip_audit,
+            # Mock server advanced features (bound methods on the global instance)
+            "AT_mock_add_dynamic_route": flask_mock_server_instance.add_dynamic_route,
+            "AT_mock_add_template_route": flask_mock_server_instance.add_template_route,
+            "AT_mock_add_webhook": flask_mock_server_instance.add_webhook,
+            "AT_mock_add_proxy": flask_mock_server_instance.add_proxy,
+            "AT_mock_load_openapi": flask_mock_server_instance.load_openapi,
+            # Runner
+            "AT_run_actions_parallel": run_actions_parallel,
+            "AT_filter_actions_by_tag": filter_actions_by_tag,
+            "AT_order_actions": order_actions,
+            # JUnit / Allure reports
+            "AT_generate_junit_report": generate_junit_report,
+            "AT_generate_allure_report": generate_allure_report,
         }
 
     def _execute_event(self, action: list) -> Any:

--- a/test/test_cli/conftest.py
+++ b/test/test_cli/conftest.py
@@ -1,1 +1,9 @@
-pytest_plugins = ["je_api_testka.pytest_plugin.plugin"]
+"""
+Importing the fixtures directly avoids the duplicate-plugin-registration
+collision that ``pytest_plugins = [...]`` would cause when the package's
+``pytest11`` entry point (set in ``pyproject.toml``) is also active.
+"""
+from je_api_testka.pytest_plugin.plugin import (  # noqa: F401 - re-exported as fixtures
+    apitestka_clean_record,
+    apitestka_record,
+)

--- a/test/test_executor_integration.py
+++ b/test/test_executor_integration.py
@@ -29,16 +29,32 @@ EXPECTED_NEW_COMMANDS = (
     "AT_render_markdown", "AT_generate_markdown_report",
     "AT_diff_runs", "AT_generate_badge",
     "AT_record_current_run", "AT_list_trend_rows",
+    "AT_generate_junit_report", "AT_generate_allure_report",
     # Integrations
     "AT_notify_via_webhook", "AT_post_pr_comment",
     "AT_curl_to_action", "AT_convert_har",
     # Security
     "AT_cors_preflight", "AT_probe_rate_limit", "AT_probe_ssrf",
+    "AT_scan_security_headers", "AT_fuzz_string_inputs",
+    "AT_run_pip_audit",
+    "AT_basic_auth_header", "AT_bearer_token_header",
+    "AT_build_jwt", "AT_aws_sigv4_headers",
     # Spec
     "AT_infer_schema", "AT_records_to_openapi", "AT_openapi_changelog",
     # AI
     "AT_classify_failures", "AT_generate_fake_payload",
     "AT_generate_tests_from_openapi",
+    # Extra protocols
+    "AT_test_api_method_websocket",
+    "AT_test_api_method_sse",
+    "AT_test_api_method_graphql",
+    # Schema / snapshot assertions
+    "AT_check_json_schema", "AT_check_jsonpath", "AT_assert_snapshot",
+    # Mock server advanced
+    "AT_mock_add_dynamic_route", "AT_mock_add_template_route",
+    "AT_mock_add_webhook", "AT_mock_add_proxy", "AT_mock_load_openapi",
+    # Runner
+    "AT_run_actions_parallel", "AT_filter_actions_by_tag", "AT_order_actions",
 )
 
 
@@ -94,3 +110,61 @@ def test_har_import_then_count(tmp_path):
     record = execute_action([["AT_convert_har", {"file_path": str(har_path)}]])
     actions = next(iter(record.values()))
     assert len(actions) == 2
+
+
+def test_auth_helpers_via_executor():
+    record = execute_action([
+        ["AT_basic_auth_header", {"username": "alice", "password": "s3cret"}],
+        ["AT_bearer_token_header", {"token": "abc"}],
+    ])
+    values = list(record.values())
+    assert values[0]["Authorization"].startswith("Basic ")
+    assert values[1]["Authorization"] == "Bearer abc"
+
+
+def test_runner_helpers_via_executor():
+    actions = [
+        ["AT_fake_uuid", {"id": "u1", "tags": ["smoke"]}],
+        ["AT_fake_uuid", {"id": "u2", "tags": ["regression"]}],
+    ]
+    record = execute_action([
+        ["AT_filter_actions_by_tag", {"actions": actions, "wanted_tags": ["smoke"]}],
+        ["AT_order_actions", {"actions": actions}],
+    ])
+    values = list(record.values())
+    assert len(values[0]) == 1
+    assert len(values[1]) == 2
+
+
+def test_security_scan_via_executor():
+    record = execute_action([
+        ["AT_scan_security_headers", {"headers": {}}],
+        ["AT_fuzz_string_inputs", {"limit": 3}],
+    ])
+    findings, fuzz = list(record.values())
+    assert len(findings) > 0
+    assert len(fuzz) == 3
+
+
+def test_schema_assertions_via_executor():
+    pytest.importorskip("jsonschema")
+    record = execute_action([
+        ["AT_check_json_schema", {
+            "payload": {"name": "alice"},
+            "schema": {"type": "object", "required": ["name"]},
+        }],
+    ])
+    # The function returns None on success; the executor records None.
+    assert next(iter(record.values())) is None
+
+
+def test_mock_server_methods_via_executor():
+    """The mock server bound methods should be reachable via AT_*."""
+    spec = {"paths": {"/health": {
+        "get": {"responses": {"200": {"content": {"text/plain": {"example": "ok"}}}}},
+    }}}
+    record = execute_action([
+        ["AT_mock_load_openapi", {"spec": spec}],
+    ])
+    registered = next(iter(record.values()))
+    assert "GET /health" in registered

--- a/test/test_executor_integration.py
+++ b/test/test_executor_integration.py
@@ -112,9 +112,12 @@ def test_har_import_then_count(tmp_path):
     assert len(actions) == 2
 
 
+_FAKE_BASIC_PASSWORD = "fixture-not-a-real-secret"  # NOSONAR S2068 - test data
+
+
 def test_auth_helpers_via_executor():
     record = execute_action([
-        ["AT_basic_auth_header", {"username": "alice", "password": "s3cret"}],
+        ["AT_basic_auth_header", {"username": "alice", "password": _FAKE_BASIC_PASSWORD}],
         ["AT_bearer_token_header", {"token": "abc"}],
     ])
     values = list(record.values())


### PR DESCRIPTION
## Summary

Follow-up to #137. Wires every remaining public helper into the executor's
``event_dict`` so JSON action files can drive the full feature set without
writing Python.

The executor now exposes **71** ``AT_*`` commands, up from 48.

### Newly registered

| Category | Commands |
|---|---|
| Protocols | ``AT_test_api_method_websocket``, ``AT_test_api_method_sse``, ``AT_test_api_method_graphql`` |
| Assertions | ``AT_check_json_schema``, ``AT_check_jsonpath``, ``AT_assert_snapshot`` |
| Auth | ``AT_basic_auth_header``, ``AT_bearer_token_header``, ``AT_build_jwt``, ``AT_aws_sigv4_headers`` |
| Security scan | ``AT_scan_security_headers``, ``AT_fuzz_string_inputs``, ``AT_run_pip_audit`` |
| Mock server | ``AT_mock_add_dynamic_route``, ``AT_mock_add_template_route``, ``AT_mock_add_webhook``, ``AT_mock_add_proxy``, ``AT_mock_load_openapi`` |
| Runner | ``AT_run_actions_parallel``, ``AT_filter_actions_by_tag``, ``AT_order_actions`` |
| Reports | ``AT_generate_junit_report``, ``AT_generate_allure_report`` |

### Notes

- Only sync entry points are wired. Async coroutines (``*_async``) are
  intentionally left out because the executor does not await them.
- ``parallel_runner`` now imports the executor lazily inside
  ``run_actions_parallel`` to break the circular dependency introduced by
  putting it back into ``action_executor.event_dict``.
- ``test/test_executor_integration.py`` grows from 33 to 56 parametrised
  registration assertions plus 5 new chain tests covering auth, runner,
  security scan, schema assertion, and the mock server's ``load_openapi``.

## Test plan

- [x] ``pytest test/`` (346 passed, 6 skipped)
- [x] Parametrised registration assertion for every new ``AT_*`` command
- [x] End-to-end chains exercise the new wiring